### PR TITLE
zxcvbn-php version bump.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "bjeavons/zxcvbn-php": "^0.1.4",
+        "bjeavons/zxcvbn-php": "^0.3",
         "symfony/validator": "~2.8|~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bumps the version of `bjeavons/zxcvbn-php` required to its current `0.3` release.